### PR TITLE
Multiple inputs compatible and outputDir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ dist/
 ### Options
 
 - `assets`: **(required)** An array of paths to copy. Accepts files as well as directories.
+- `outputDir`: A string that represents a directory. All assets files will be here instead of using each file path.
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,20 +9,35 @@ import path from 'path';
  * @return {Object} The rollup code object.
  */
 export default function copy(options = {}) {
-  const { assets } = options;
+  const { assets, outputDir } = options;
   let basedir = '';
   return {
     name: 'copy-assets',
     options: function options(options) {
       // Cache the base directory so we can figure out where to put assets.
-      basedir = path.dirname(options.input);
+      // Handling input as array
+      const inputStr = Array.isArray(options.input)
+        ? options.input[0]
+        : options.input;
+      basedir = path.dirname(inputStr);
     },
     generateBundle: ({ file, dir }) => {
       const outputDirectory = dir || path.dirname(file);
-      return Promise.all(assets.map((asset) => fs.copy(
-        asset,
-        path.join(outputDirectory, path.relative(basedir, asset))
-      )));
+      return Promise.all(
+        assets.map((asset) => {
+          // console.log(!!outputDir, outputDir, dir);
+          const isFolder = !path.basename(asset).includes('.');
+          const out = !!outputDir
+            ? path.join(
+                outputDirectory,
+                outputDir,
+                isFolder ? '' : path.basename(asset)
+              )
+            : path.join(outputDirectory, path.relative(basedir, asset));
+          console.log(out);
+          return fs.copy(asset, out);
+        })
+      );
     },
   };
 }

--- a/test/fixtures/index2.js
+++ b/test/fixtures/index2.js
@@ -1,0 +1,2 @@
+const test = 'test';
+export default test;

--- a/test/tests.js
+++ b/test/tests.js
@@ -37,6 +37,35 @@ describe('rollup-plugin-copy-assets', function() {
       assertExists('output/assets/bar.csv'),
     ]))
     .then(() => done());
+
+  it('should copy assets to outputDir as base folder when present', function(done) {
+    build({
+      assets: ['fixtures/assets', 'fixtures/top-level-item.txt'],
+      outputDir: 'testDir',
+    })
+      .then(() =>
+        Promise.all([
+          // assertExists('output/testDir'),
+          assertExists('output/testDir/foo.txt'),
+          assertExists('output/testDir/bar.csv'),
+          assertExists('output/testDir/top-level-item.txt'),
+        ])
+      )
+      .then(() => done());
+  });
+
+  it('should be compatible with array of string as input on rollup config', function(done) {
+    buildWithMultipleInput({
+      assets: ['fixtures/assets', 'fixtures/top-level-item.txt'],
+      outputDir: 'testDir',
+    })
+      .then(() =>
+        Promise.all([
+          assertExists('output/index.js'),
+          assertExists('output/index2.js'),
+        ])
+      )
+      .then(() => done());
   });
 });
 
@@ -44,14 +73,25 @@ describe('rollup-plugin-copy-assets', function() {
 function build(config) {
   return rollup({
     input: './fixtures/index.js',
-    plugins: [
-      copy(config),
-    ],
-  }).then(bundle => bundle.write({
-    file: 'output/bundle.js',
-    format: 'iife',
-    name: 'test',
-  }));
+    plugins: [copy(config)],
+  }).then((bundle) =>
+    bundle.write({
+      file: 'output/bundle.js',
+      format: 'iife',
+      name: 'test',
+    })
+  );
+}
+
+// Run the rollup build with an plugin configuration compatible with multiple inputs.
+function buildWithMultipleInput(config) {
+  return rollup({
+    input: ['./fixtures/index.js', './fixtures/index2.js'],
+    plugins: [copy(config)],
+    experimentalCodeSplitting: true,
+  }).then((bundle) =>
+    bundle.write({ dir: 'output/', format: 'es', name: 'test' })
+  );
 }
 
 // Asserts that a file does or does not exist.


### PR DESCRIPTION
Compatible with `array` as input on rollup config; new `outputDir` option available, to store assets in an specific folder.